### PR TITLE
Remove legacy allTests arrays - Swift 6.0 auto-discovers tests

### DIFF
--- a/Tests/CommandLineTests/CLIOptionTests.swift
+++ b/Tests/CommandLineTests/CLIOptionTests.swift
@@ -64,10 +64,4 @@ class CLIOptionTests : XCTestCase {
     XCTAssertEqual(option.arguments, ["a", "-f"])
   }
 
-  static let allTests = [
-    ("testNoOption", testNoOption),
-    ("testFlags", testFlags),
-    ("testStringOptions", testStringOptions),
-    ("testDictionaryOptions", testDictionaryOptions),
-  ]
 }

--- a/Tests/DotYanagibaTests/DotYanagibaMergeTests.swift
+++ b/Tests/DotYanagibaTests/DotYanagibaMergeTests.swift
@@ -82,8 +82,4 @@ class DotYanagibaMergeTests : XCTestCase {
     XCTAssertEqual(result21.modules["xyz"]?.options["b"], DotYanagiba.Module.Option.string("b"))
   }
 
-  static let allTests = [
-    ("testCombine", testCombine),
-    ("testResolve", testResolve),
-  ]
 }

--- a/Tests/DotYanagibaTests/DotYanagibaParserTests.swift
+++ b/Tests/DotYanagibaTests/DotYanagibaParserTests.swift
@@ -164,13 +164,4 @@ class DotYanagibaParserTests : XCTestCase {
     XCTAssertNil(result.modules["foobar"])
   }
 
-  static let allTests = [
-    ("testIntOption", testIntOption),
-    ("testStringOption", testStringOption),
-    ("testListIntOption", testListIntOption),
-    ("testListStringOption", testListStringOption),
-    ("testDictIntOption", testDictIntOption),
-    ("testDictStringOption", testDictStringOption),
-    ("testMultiModules", testMultiModules),
-  ]
 }

--- a/Tests/SwiftExtensionsTests/StringIdentationTests.swift
+++ b/Tests/SwiftExtensionsTests/StringIdentationTests.swift
@@ -50,9 +50,4 @@ class StringIdentationTests : XCTestCase {
     XCTAssertEqual("\n\n\n".indented, "  \n  \n  \n  ")
   }
 
-  static let allTests = [
-    ("testIdentationInitializer", testIdentationInitializer),
-    ("testStaticIndent", testStaticIndent),
-    ("testIndented", testIndented),
-  ]
 }

--- a/Tests/SwiftExtensionsTests/StringPathTests.swift
+++ b/Tests/SwiftExtensionsTests/StringPathTests.swift
@@ -52,11 +52,4 @@ class StringPathTests : XCTestCase {
     XCTAssertEqual(["/path/to/foo", "/path/to/bar", "/path/bar"].commonPathPrefix, "/path/")
   }
 
-  static let allTests = [
-    ("testTruncatedPath", testTruncatedPath),
-    ("testTruncatedPathWithPrefixNoMatch", testTruncatedPathWithPrefixNoMatch),
-    ("testAbsolutePath", testAbsolutePath),
-    ("testParentPath", testParentPath),
-    ("testCommonPathPrefix", testCommonPathPrefix),
-  ]
 }

--- a/Tests/SwiftExtensionsTests/StringTTYColorTests.swift
+++ b/Tests/SwiftExtensionsTests/StringTTYColorTests.swift
@@ -43,8 +43,4 @@ class StringTTYColorTests : XCTestCase {
     XCTAssertEqual("abc".colored(with: .default), "\u{001B}[0mabc\u{001B}[0m")
   }
 
-  static let allTests = [
-    ("testColorTTYCode", testColorTTYCode),
-    ("testColoredString", testColoredString),
-  ]
 }


### PR DESCRIPTION
## Summary

Removes the legacy `static let allTests` arrays from all test files.

## Context

The `allTests` pattern was required for XCTest on Linux in Swift < 5.0. With `swift-tools-version:6.0`, test discovery is automatic — no manual registration needed.

## Files Changed

- `StringTTYColorTests.swift`
- `StringPathTests.swift`
- `StringIdentationTests.swift`
- `DotYanagibaMergeTests.swift`
- `DotYanagibaParserTests.swift`
- `CLIOptionTests.swift`

Note: `SerinusTests.swift` already didn't have this pattern, confirming it's not needed.

## Testing

- [ ] Run `swift test` locally
- [ ] CI passes