### PR TITLE
fix(ci): use swift test with code coverage on macOS

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,10 +38,7 @@ jobs:
       - name: Swift version
         run: swift --version
       - name: Run tests
-        run: make test
+        run: swift test --enable-code-coverage
       # - name: Lint
       #   run: ./lint.sh
-      - name: Xcode build
-        run: |
-          xcodebuild -scheme bocho -destination "platform=macOS" -configuration Debug -enableCodeCoverage YES test
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,4 +41,16 @@ jobs:
         run: swift test --enable-code-coverage
       # - name: Lint
       #   run: ./lint.sh
+      - name: Convert coverage to lcov
+        run: |
+          BIN_PATH=$(swift build --show-bin-path)
+          XCTEST_BUNDLE=$(find "$BIN_PATH" -name "*.xctest" -type d | head -1)
+          xcrun llvm-cov export \
+            "$XCTEST_BUNDLE/Contents/MacOS/$(basename "$XCTEST_BUNDLE" .xctest)" \
+            -instr-profile "$BIN_PATH/codecov/default.profdata" \
+            -format lcov \
+            > coverage.lcov
       - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILD_DIR=.build/debug
 
-.PHONY: all clean build test xcodegen
+.PHONY: all clean build test
 
 all: build
 
@@ -12,6 +12,3 @@ build:
 
 test: build
 	swift test
-
-xcodegen:
-	swift package generate-xcodeproj --enable-code-coverage


### PR DESCRIPTION
## Summary

Fixes macOS CI build failure by using `swift test --enable-code-coverage` instead of xcodebuild.

## Problem

The macOS CI was failing because:
1. It tried to run `xcodebuild -scheme bocho` without an Xcode project
2. `swift package generate-xcodeproj` was removed in Swift 6

## Solution

Use `swift test --enable-code-coverage` directly, which is the recommended approach for Swift 6 packages.

## Testing

- ✅ Tests on Linux: Passed
- ✅ Tests on macOS: Passed